### PR TITLE
Fetch all repos

### DIFF
--- a/github.js
+++ b/github.js
@@ -234,25 +234,24 @@
       var repos = [];
       var username = this.username;
 
-      page = 1;
+      var page = 1;
 
-      var _exitCallback = function (data) { callback.apply(context, arguments) };
+      var exitCallback = function (repos) { callback.call(context, { repositories: repos }) };
       
-      var _callback = function (data) {
+      var pageLoop = function (data) {
         repos = repos.concat(data.repositories);
-        console.log(data);
         var reposLength = data.repositories.length;
 
         if (reposLength == 0) {
-          _exitCallback(repos);
+          exitCallback(repos);
         }
         else {
           page += 1;
-          gh.repo.forUser(username, _callback, context, page);
+          gh.repo.forUser(username, pageLoop, context, page);
         }
       }
 
-      gh.repo.forUser(username, _callback, context, page);
+      gh.repo.forUser(username, pageLoop, context, page);
       
       return this;
     }


### PR DESCRIPTION
Hi, I've added an optional page parameter to gh.user.prototype.repos so that you can specify which page to fetch (by default it only fetches the first 30, or 100 in some cases).

I also added a convenience method that fetches all repos for a user:
gh.user("drnic").allRepos(function (repos) {
  alert(repos.length);
 });

I hope this helps. I would like to see it included in your library.
