### PR TITLE
Fix error with iframe content reference. Closes #8

### DIFF
--- a/github.js
+++ b/github.js
@@ -60,7 +60,12 @@
     post = function (url, vals) {
         var
         form = document.createElement("form"),
-        iframe = document.createElement("iframe"),
+        iframe = document.createElement("iframe");
+
+        // Need to insert the iframe now so contentDocument and contentWindow are defined
+        document.body.appendChild(iframe);
+
+        var
         doc = iframe.contentDocument !== undefined ?
             iframe.contentDocument :
             iframe.contentWindow.document,
@@ -80,7 +85,6 @@
 
         iframe.setAttribute("style", "display: none;");
         doc.body.appendChild(form);
-        document.body.appendChild(iframe);
         form.submit();
     },
 


### PR DESCRIPTION
The iframe needs to be added to the page before referencing it's contentDocument or contentWindow properties. This closes issue #8.
