### PR TITLE
Added user.orgs function to get list of user's organizations

### DIFF
--- a/github.js
+++ b/github.js
@@ -215,6 +215,16 @@
         return this;
     };
 
+    // Get a list of organizations that this user belongs to.
+    //
+    //     gh.user("fitzgen").organizations( function(data) {
+    //         alert(data.organizations.length);
+    //     });
+    gh.user.prototype.orgs = function (callback, context) {
+       jsonp("user/show/" + this.username + "/organizations", callback, context);
+       return this
+    };
+
     // Get a list of this user's repositories, 30 per page
     //
     //     gh.user("fitzgen").repos(function (data) {


### PR DESCRIPTION
I created a method on the user prototype to retrieve the user's Organizations.

[Relevant Github API v2 docs for orgs](http://develop.github.com/p/orgs.html).

Example usage:

``` js
gh.user("JangoSteve").organizations( function(data) {
  console.log(data);
});

// =>
{"organizations":[{"gravatar_id":"30f39a09e233e8369dddf6feb4be0308","blog":"http://weblog.rubyonrails.org/","type":"Organization","login":"rails"}]}
```
