### PR TITLE
Fixed jsonp URLs with token authentication

### DIFF
--- a/github.js
+++ b/github.js
@@ -43,7 +43,7 @@
 
         url += prefix + "callback=" + encodeURIComponent("gh.__jsonp_callbacks[" + id + "]");
         if (authUsername && authToken) {
-            url += "&login=" + authUsername + "&authToken=" + authToken;
+            url += "&login=" + authUsername + "&token=" + authToken;
         }
         script.setAttribute("src", apiRoot + url);
 


### PR DESCRIPTION
I was getting 401 Unauthorized responses from the api when trying to use any of the jsonp calls that required authentication.

I checked the v2 docs and they say [the api token should be passed as the `token` variable](http://develop.github.com/p/general.html) in the request URL. But github-api was calling it `authToken` in the URL. So, I changed it and everything worked and unicorns waltzed into my office and danced a merry jig.
