### PR TITLE
Added user.allOrgRepos method to get list of all user's organization repos

### DIFF
--- a/github.js
+++ b/github.js
@@ -215,6 +215,20 @@
         return this;
     };
 
+    // Get a list of all organization repos this user has access to.
+    //
+    //     gh.authenticate("fitzgen", <token>);
+    //     user = gh.user("fitzen");
+    //
+    //     user.allOrgRepos(function (data) {
+    //         alert(data.repositories.length);
+    //     });
+    gh.user.prototype.allOrgRepos = function (callback) {
+       authRequired(this.username);
+       jsonp("organizations/repositories", callback);
+       return this;
+    };
+
     // Get a list of this user's repositories, 30 per page
     //
     //     gh.user("fitzgen").repos(function (data) {


### PR DESCRIPTION
Added function to get all repos a user has access to from the user's organizations.

See the "Listing Organization Memberships" section in the [Github v2 Orgs docs](http://develop.github.com/p/orgs.html).

Example usage:

``` js
gh.authenticate("fitzgen", <authToken>);
user = gh.user("fitzen");

user.allOrgRepos(function (data) {
  alert(data.repositories.length);
});
```
